### PR TITLE
CSS: Vertical Centering and wrapping for skill icons

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -81,21 +81,15 @@ div#top {
     height: 30px;
 }
 
-.div-img-icon {
-    width: 25%;
-    height: 100px;
-    position: relative;
-    vertical-align: middle;
-}
-
-.img-icon {
-  max-height: 100%;
-  max-width: 100%;
+.skill-icon {
+  max-height: 100px;
+  max-width: 300px;
   top: 0;
   bottom: 0;
   right: 0;
   left: 0;
   margin: auto;
+  padding: 10px;
 }
 
 h1 {

--- a/index.html
+++ b/index.html
@@ -76,19 +76,10 @@
         <h2>Programming</h2>
         <div class="row-content">
         <div class="row">
-          <div class="col-md-3 div-img-icon">
-            <img class="img-icon" src="img/cpp_logo.png">
-          </div>
-          <div class="col-md-3 div-img-icon">
-            <img class="img-icon" src="img/python_logo.png">
-          </div>
-          <div class="col-md-3 div-img-icon">
-            <img class="img-icon" src="img/ros_logo.png"">
-          </div>
-          <div class="col-md-3 div-img-icon">
-            <img class="img-icon" src="img/pytorch_logo.png"">
-          </div>
-          </div>
+          <img class="skill-icon" src="img/cpp_logo.png">
+          <img class="skill-icon" src="img/python_logo.png">
+          <img class="skill-icon" src="img/ros_logo.png">
+          <img class="skill-icon" src="img/pytorch_logo.png">
         </div>
 
         <h2>Languages</h2>


### PR DESCRIPTION
Before centering:
![image](https://user-images.githubusercontent.com/10286050/76184911-04a35300-6211-11ea-9646-4da426877306.png)
After:
![image](https://user-images.githubusercontent.com/10286050/76185368-687a4b80-6212-11ea-8ab5-4e20f6c195b3.png)

Also wrapping is enabled if page width is narrow:
![image](https://user-images.githubusercontent.com/10286050/76185519-bd1dc680-6212-11ea-988b-d7caef979709.png)
